### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Jimi：打造Java程序员专属的开源ClaudeCode
 
+[![Run in Smithery](https://smithery.ai/badge/skills/leavesfly)](https://smithery.ai/skills?ns=leavesfly&utm_source=github&utm_medium=badge)
+
+
 > 一个完全用Java实现的AI驱动CLI智能代理系统，为Java开发者带来可深度定制的类ClaudeCode开源。
 
 [![Java](https://img.shields.io/badge/Java-17+-orange.svg)](https://www.oracle.com/java/)


### PR DESCRIPTION
## Add skill discoverability badge

Your 9 Claude skills are already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/Leavesfly)](https://smithery.ai/skills?ns=Leavesfly&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.